### PR TITLE
added deletion of versions from  plainrevs plugin

### DIFF
--- a/$__plugins_kookma_trashbin_macros_move-to-trashbin.json
+++ b/$__plugins_kookma_trashbin_macros_move-to-trashbin.json
@@ -1,0 +1,12 @@
+[
+    {
+        "created": "20190710071039480",
+        "creator": "HC Haase",
+        "title": "$:/plugins/kookma/trashbin/macros/move-to-trashbin",
+        "modified": "20190917122911680",
+        "tags": "$:/tags/Macro",
+        "type": "text/vnd.tiddlywiki",
+        "text": "\\define trashTidName() <<unusedtitle baseName:\"$(trashTiddler)$\">>\n\n\\define move-to-trashbin(tiddler)\n<$vars trashTiddler={{{ [<__tiddler__>addprefix[$:/trashbin/]] }}}>\n<$wikify name=\"trashTid\" text=<<trashTidName>> >\n<$list filter=\"[<__tiddler__>fields[]]\" variable=\"fieldName\">\n<$action-setfield \n $tiddler=<<trashTid>>\n $index=<<fieldName>>\n $value={{{[<__tiddler__>get<fieldName>] }}}\n/>\n</$list>\n<$action-setfield $tiddler=<<trashTid>> tags=\"$:/tags/trashbin\"/>\n</$wikify>\n<$action-sendmessage $message=\"tm-close-tiddler\" $param=<<__tiddler__>> />\n<$action-deletetiddler $tiddler=<<__tiddler__>> />\n</$vars>\n<$action-deletetiddler $filter=\"[<currentTiddler>listed[]prefix[$:/rev]!has[pin]]\"/>\n\\end\n",
+        "modifier": "HC Haase"
+    }
+]


### PR DESCRIPTION
I use jd's revision plugin and also want to use your trash bin plugin, but that would leave revision tidderls "floating free" without any reference tiddler, thus I made your plugin delete them. I would be better to also move them to the trashbin, but I dont have the skills to do that, and this is better than letting them fill up your wiki.

----

I added a line to also delete any revision tiddlers made by the  plainrevs plugin by jd. 

NB: the revision tiddlers are NOT moved to trash, permanently deleted!!
( I dont have the insight to do that)

ps. sorry for the clumsy pr. I cant find the tiddler in your repo. I hope it makes sense for your. I just copied a line form jd's plugin into the tiddler.